### PR TITLE
feat: ブログ記事一覧をリスト表示する ( / )

### DIFF
--- a/src/components/BlogCard.tsx
+++ b/src/components/BlogCard.tsx
@@ -1,0 +1,12 @@
+import { BlogInfo } from "@/types/BlogInfo";
+
+// idとuserImageは今後のIssueで使用するため、まだ追加していません。
+export const BlogCard = ({ title, userName }: BlogInfo) => {
+  return (
+    <div className="border p-4 mb-4 rounded-md shadow-sm">
+      <p className="text-sm text-gray-500">ユーザー: {userName}</p>
+      <h2 className="text-lg font-bold text-blue-600">{title}</h2>
+      {/* Issue 3でここに shadcn/ui の Avatar などを組み込みます */}
+    </div>
+  );
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,6 +20,11 @@ const API_BASE_URL = "http://localhost:5678/api/blogs";
 export const getServerSideProps: GetServerSideProps = async () => {
   try {
     const res = await fetch(`${API_BASE_URL}`);
+
+    if (!res.ok) {
+      throw new Error(`API Error: ${res.status} ${res.statusText}`);
+    }
+
     const blogs = await res.json();
 
     return {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,9 @@
 import { GetServerSideProps } from "next";
+import { BlogInfo } from "@/types/BlogInfo";
+import { BlogCard } from "@/components/BlogCard";
 import Head from "next/head";
 
-export default function Home() {
+export default function Home({ blogs }: { blogs: BlogInfo[] }) {
   return (
     <>
       <Head>
@@ -9,8 +11,22 @@ export default function Home() {
         <meta name="description" content="記事一覧ページです。" />
       </Head>
 
-      {/* 今後のIssueでここにレイアウトやBlogCardコンポーネントを追加していきます */}
-      <h1>ブログ記事一覧</h1>
+      <section className="space-y-4">
+        <h1 className="text-2xl font-bold mb-6">ブログ記事一覧</h1>
+
+        <ul className="space-y-4">
+          {blogs.map((blog) => (
+            <li key={blog.id}>
+              <BlogCard
+                id={blog.id}
+                title={blog.title}
+                userName={blog.userName}
+                userImage={blog.userImage}
+              />
+            </li>
+          ))}
+        </ul>
+      </section>
     </>
   );
 }
@@ -25,7 +41,7 @@ export const getServerSideProps: GetServerSideProps = async () => {
       throw new Error(`API Error: ${res.status} ${res.statusText}`);
     }
 
-    const blogs = await res.json();
+    const blogs: BlogInfo[] = await res.json();
 
     return {
       props: {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import { GetServerSideProps } from "next";
 import Head from "next/head";
 
 export default function Home() {
@@ -13,3 +14,19 @@ export default function Home() {
     </>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  try {
+    const res = await fetch("http://localhost:5678/api/blogs");
+    const blogs = await res.json();
+
+    return {
+      props: {
+        blogs,
+      },
+    };
+  } catch (error) {
+    console.error("データ取得エラー:", error);
+    return { props: { blogs: [] } };
+  }
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,9 +15,11 @@ export default function Home() {
   );
 }
 
+const API_BASE_URL = "http://localhost:5678/api/blogs";
+
 export const getServerSideProps: GetServerSideProps = async () => {
   try {
-    const res = await fetch("http://localhost:5678/api/blogs");
+    const res = await fetch(`${API_BASE_URL}`);
     const blogs = await res.json();
 
     return {

--- a/src/types/BlogInfo.ts
+++ b/src/types/BlogInfo.ts
@@ -1,0 +1,6 @@
+export type BlogInfo = {
+  id: string;
+  title: string;
+  userName: string;
+  userImage: string;
+};


### PR DESCRIPTION
# Issue3 (feature/blog-list)

### やったこと
1. 型定義の作成 (`src/types/BlogInfo.ts`)
   - APIのレスポンス形式に合わせ、ブログ記事の情報を管理するインターフェースを定義。
2. ダミーの BlogCard コンポーネント作成 (`src/components/BlogCard.tsx`)
   - ブログ一覧を表示するための器を作成。将来的な拡張（Issue 3）を考慮しつつ、現在は表示に必要なPropsのみを抽出して実装。
3. SSRによるデータフェッチ実装 (`src/pages/index.tsx`)
   - `getServerSideProps` を用いて、サーバーサイドでバックエンドAPIから記事一覧を取得するロジックを構築。
4. APIエンドポイントURLの定数化や防御的プログラミングの取り入れによるリファクタリング
5. 記事一覧のリストレンダリング
   - 取得したデータを `map` 関数で展開し、Reactのベストプラクティスに従い適切な `key` を設定して描画。

### 検索したこと
1. **Next.js のデータフェッチ (getServerSideProps)**
   - 自分なりの結論: サーバー側でデータを取得してからHTMLを生成するSSRの基本的な流れを理解した。コンポーネントと同じファイルからexportする必要がある点も確認。
   - 参考ソース: [Next.js公式ドキュメント - Data Fetching](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props)

2. **fetch API のエラーハンドリング**
   - 自分なりの結論: `fetch` はHTTPステータスコードがエラー（404や500）でも例外を投げないため、`res.ok` を用いた明示的なエラー判定が必須であることを学んだ。
   - 参考ソース: [MDN - Fetch API の使用](https://developer.mozilla.org/ja/docs/Web/API/Fetch_API/Using_Fetch#%E3%83%95%E3%82%A7%E3%83%83%E3%83%81%E3%81%AE%E6%88%90%E5%8A%9F%E3%81%AE%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF)

3. **React のリスト描画における key プロパティ**
   - 自分なりの結論: ReactがDOMを効率的に更新し、予期せぬ状態の不整合を防ぐために、一意な `key` の設定が不可欠であることを再認識した。
   - 参考ソース: [React公式ドキュメント - Rendering Lists](https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key)

### わかったこと
- Next.jsのPages RouterにおけるSSRの流れ（サーバー側でフェッチ → Propsとしてページへ渡す）を、実際のコードを通じて深く理解できた。
- リーダブルコードの原則に基づき、変数のスコープを最小限にするために定数（APIのURLなど）を直前で定義することの重要性。

### 詰まったこと
- **問題:** 最初、APIのURLを `http://localhost:5678/blogs` としていたが、サーバーから「404 Not Found」が返ってきた。
- **解決方法:** 今回追加した `!res.ok` のエラー判定により、即座にAPI側のルーティングの問題であることに気づけた。バックエンドのソースコードを確認したところ、共通の `basePath` として `/api` が設定されていることが判明したため、URLを修正して解決した。

**【⚠️ レビュアーの方へ】**
このPRは `feature/layout` (Issue 1) から派生しています。
差分をIssue 2の内容のみに絞るため、一時的に `base` ブランチを `feature/layout` に設定しています。最終的には `main` へマージ予定です。