### PR TITLE
feat: blog card を作成する

### DIFF
--- a/src/components/AuthorInfo.tsx
+++ b/src/components/AuthorInfo.tsx
@@ -1,9 +1,7 @@
+import { BlogInfo } from "@/types/BlogInfo";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
-type AuthorInfoProps = {
-  userName: string;
-  userImage: string;
-};
+type AuthorInfoProps = Pick<BlogInfo, "userName" | "userImage">;
 
 export const AuthorInfo = ({ userName, userImage }: AuthorInfoProps) => {
   {/* セマンティクスは親で確定する設計にする！ここは再利用性重視で div を採用。*/}

--- a/src/components/AuthorInfo.tsx
+++ b/src/components/AuthorInfo.tsx
@@ -9,7 +9,10 @@ export const AuthorInfo = ({ userName, userImage }: AuthorInfoProps) => {
     <div className="flex items-center space-x-3">
       <Avatar>
         <AvatarImage src={userImage} alt={userName} />
-        <AvatarFallback>{userName.charAt(0)}</AvatarFallback>
+        <AvatarFallback>
+          {/* userNameが空文字の場合は '?' などを出し、存在する場合は大文字にして返す */}
+          {userName ? userName.charAt(0).toUpperCase() : "?"}
+        </AvatarFallback>
       </Avatar>
       <span className="text-sm font-medium text-gray-700">{userName}</span>
     </div>

--- a/src/components/AuthorInfo.tsx
+++ b/src/components/AuthorInfo.tsx
@@ -1,0 +1,19 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+type AuthorInfoProps = {
+  userName: string;
+  userImage: string;
+};
+
+export const AuthorInfo = ({ userName, userImage }: AuthorInfoProps) => {
+  {/* セマンティクスは親で確定する設計にする！ここは再利用性重視で div を採用。*/}
+  return (
+    <div className="flex items-center space-x-3">
+      <Avatar>
+        <AvatarImage src={userImage} alt={userName} />
+        <AvatarFallback>{userName.charAt(0)}</AvatarFallback>
+      </Avatar>
+      <span className="text-sm font-medium text-gray-700">{userName}</span>
+    </div>
+  );
+};

--- a/src/components/BlogCard.tsx
+++ b/src/components/BlogCard.tsx
@@ -1,12 +1,19 @@
 import { BlogInfo } from "@/types/BlogInfo";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { AuthorInfo } from "@/components/AuthorInfo";
 
-// idとuserImageは今後のIssueで使用するため、まだ追加していません。
-export const BlogCard = ({ title, userName }: BlogInfo) => {
+// idは今後のIssueで使用する予定なので、現在は含めていない。
+export const BlogCard = ({ title, userName, userImage }: BlogInfo) => {
   return (
-    <div className="border p-4 mb-4 rounded-md shadow-sm">
-      <p className="text-sm text-gray-500">ユーザー: {userName}</p>
-      <h2 className="text-lg font-bold text-blue-600">{title}</h2>
-      {/* Issue 3でここに shadcn/ui の Avatar などを組み込みます */}
-    </div>
+    <Card className="hover:bg-gray-50 transition-colors duration-200 cursor-pointer mb-4">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-xl font-bold leading-snug">
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <AuthorInfo userName={userName} userImage={userImage} />
+      </CardContent>
+    </Card>
   );
 };

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,110 @@
+import * as React from "react"
+import { Avatar as AvatarPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root> & {
+  size?: "default" | "sm" | "lg"
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn(
+        "aspect-square size-full rounded-full object-cover",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground bg-blend-color ring-2 ring-background select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarBadge,
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}


### PR DESCRIPTION
# Issue4 (feature/blog-card)

### やったこと
1. `shadcn/ui`のCardとAvatarコンポーネントを導入
   - `pnpm shadcn@latest add card avatar` を実行し、UI構築に必要な部品を追加。
2. `AuthorInfo` コンポーネントの切り出し（作成） (`src/components/AuthorInfo.tsx`)
   - ユーザーのアイコンと名前を横並びで表示する部品を独立したコンポーネントとして作成。
3. `BlogCard` コンポーネントのUI実装 (`src/components/BlogCard.tsx`)
   - ダミーだった実装を `shadcn/ui` の `Card` を用いたデザインに書き換え、`AuthorInfo` を内部に組み込み。
4. AuthorInfoの型定義でBlogInfo型を利用し、Pickで定義
   - `AuthorInfoProps` を `Pick<BlogInfo, "userName" | "userImage">` に変更し、既存の型定義を再利用して型の一貫性を向上。
5. AuthorInfoのフォールバック表示ロジックを改善
   - `AvatarFallback` の表示を改善し、`userName` が空文字の場合は `?` を表示、値がある場合は先頭文字を大文字で表示するように修正。

### 検索したこと
1. **shadcn/ui の Card コンポーネントの構造**
   - 自分なりの結論: `Card`, `CardHeader`, `CardTitle`, `CardContent` などのパーツを組み合わせて柔軟にカードUIを構築できることを確認した。
   - 参考ソース: [shadcn/ui公式ドキュメント - Card](https://ui.shadcn.com/docs/components/card)

2. **TypeScriptのユーティリティ型 (Pick) の使い方**
   - 自分なりの結論: 既存の型（今回は `BlogInfo`）から特定のプロパティだけを抽出して新しい型を作ることで、型の二重管理を防げる（SSOT）ことを学んだ。
   - 参考ソース: [TypeScript公式ドキュメント - Utility Types (Pick)](https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys)

### わかったこと
- **関心の分離とYAGNI原則:** `BlogCard` の引数として `id` を現状は受け取らない（Issue 4のルーティング実装時に追加する）ことで、今必要なデータのみを扱うシンプルな設計を維持できた。
- **DRY原則と型の単一情報源 (SSOT):** `AuthorInfo` のProps型を `Pick<BlogInfo, "userName" | "userImage">` と定義することで、API側の型変更に自動追従できる堅牢なコードになった。
- **防御的プログラミング:** `AvatarFallback` において、`userName` が空文字等の異常なデータだった場合に備え、フォールバックとして `?` を表示する安全なロジックを実装できた。

### 🔍 Issueで質問されたポイント（重要）
> **AuthorInfoコンポーネントの切り出し理由:** BlogCard.tsxと今後実装する記事詳細ページ（[id].tsx）の両方で共通利用するため。

### 詰まったこと
- 特になし。

**【⚠️ レビュアーの方へ】**
このPRは `feature/blog-list` (Issue 2) から派生しています。
差分をIssue 3の（feature/blog-card）ブランチ内容のみに絞るため、一時的に `base` ブランチを `feature/blog-list` に設定しています。最終的には `main` へマージ予定です。