### PR TITLE
feat: ブログ記事を取得し、表示する ( /blog/[:id] )

### DIFF
--- a/src/components/BlogCard.tsx
+++ b/src/components/BlogCard.tsx
@@ -1,19 +1,21 @@
+import Link from "next/link";
 import { BlogInfo } from "@/types/BlogInfo";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { AuthorInfo } from "@/components/AuthorInfo";
 
-// idは今後のIssueで使用する予定なので、現在は含めていない。
-export const BlogCard = ({ title, userName, userImage }: BlogInfo) => {
+export const BlogCard = ({ id, title, userName, userImage }: BlogInfo) => {
   return (
-    <Card className="hover:bg-gray-50 transition-colors duration-200 cursor-pointer mb-4">
-      <CardHeader className="pb-3">
-        <CardTitle className="text-xl font-bold leading-snug">
-          {title}
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <AuthorInfo userName={userName} userImage={userImage} />
-      </CardContent>
-    </Card>
+    <Link href={`/blogs/${id}`} className="block mb-4 cursor-pointer">
+      <Card className="hover:bg-gray-50 transition-colors duration-200">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xl font-bold leading-snug">
+            {title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <AuthorInfo userName={userName} userImage={userImage} />
+        </CardContent>
+      </Card>
+    </Link>
   );
 };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = "http://localhost:5678/api/blogs";

--- a/src/pages/blogs/[id].tsx
+++ b/src/pages/blogs/[id].tsx
@@ -2,6 +2,7 @@ import { GetServerSideProps } from "next";
 import Head from "next/head";
 import { BlogDetail } from "@/types/BlogDetail";
 import { AuthorInfo } from "@/components/AuthorInfo";
+import { API_BASE_URL } from "@/lib/constants";
 
 export default function BlogDetailPage({ blog }: { blog: BlogDetail }) {
   return (
@@ -32,8 +33,6 @@ export default function BlogDetailPage({ blog }: { blog: BlogDetail }) {
     </>
   );
 }
-
-const API_BASE_URL = "http://localhost:5678/api/blogs";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const id = context.params?.id;

--- a/src/pages/blogs/[id].tsx
+++ b/src/pages/blogs/[id].tsx
@@ -1,24 +1,35 @@
 import { GetServerSideProps } from "next";
+import Head from "next/head";
 import { BlogDetail } from "@/types/BlogDetail";
 import { AuthorInfo } from "@/components/AuthorInfo";
 
 export default function BlogDetailPage({ blog }: { blog: BlogDetail }) {
   return (
-    <article className="max-w-3xl mx-auto py-8">
-      <header>
-        <h1 className="text-3xl font-bold mb-6">{blog.title}</h1>
+    <>
+      <Head>
+        <title>Algo Blog | {blog.title}</title>
+        <meta
+          name="description"
+          content={`${blog.userName}による記事の詳細ページです。`}
+        />
+      </Head>
 
-        <address className="mb-8">
-          <AuthorInfo userName={blog.userName} userImage={blog.userImage} />
-        </address>
-      </header>
+      <article className="max-w-3xl mx-auto py-8">
+        <header>
+          <h1 className="text-3xl font-bold mb-6">{blog.title}</h1>
 
-      <section className="bg-gray-50 p-6 rounded-md border">
-        <div className="whitespace-pre-wrap text-gray-800">
-          {blog.content}
-        </div>
-      </section>
-    </article>
+          <address className="mb-8">
+            <AuthorInfo userName={blog.userName} userImage={blog.userImage} />
+          </address>
+        </header>
+
+        <section className="bg-gray-50 p-6 rounded-md border">
+          <div className="whitespace-pre-wrap text-gray-800">
+            {blog.content}
+          </div>
+        </section>
+      </article>
+    </>
   );
 }
 

--- a/src/pages/blogs/[id].tsx
+++ b/src/pages/blogs/[id].tsx
@@ -1,4 +1,5 @@
 import { GetServerSideProps } from "next";
+import { BlogDetail } from "@/types/BlogDetail";
 
 const API_BASE_URL = "http://localhost:5678/api/blogs";
 
@@ -16,7 +17,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       throw new Error(`API Error: ${res.status}`);
     }
 
-    const blog = await res.json();
+    const blog: BlogDetail = await res.json();
 
     return {
       props: {

--- a/src/pages/blogs/[id].tsx
+++ b/src/pages/blogs/[id].tsx
@@ -1,0 +1,22 @@
+import { GetServerSideProps } from "next";
+
+const API_BASE_URL = "http://localhost:5678/api/blogs";
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const id = context.params?.id;
+
+  try {
+    const res = await fetch(`${API_BASE_URL}/${id}`);
+
+    const blog = await res.json();
+
+    return {
+      props: {
+        blog,
+      },
+    };
+  } catch (error) {
+    console.error("個別記事取得エラー:", error);
+    return { notFound: true };
+  }
+};

--- a/src/pages/blogs/[id].tsx
+++ b/src/pages/blogs/[id].tsx
@@ -37,6 +37,10 @@ export default function BlogDetailPage({ blog }: { blog: BlogDetail }) {
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const id = context.params?.id;
 
+  if (typeof id !== "string") {
+    return { notFound: true };
+  }
+
   try {
     const res = await fetch(`${API_BASE_URL}/${id}`);
 

--- a/src/pages/blogs/[id].tsx
+++ b/src/pages/blogs/[id].tsx
@@ -1,5 +1,26 @@
 import { GetServerSideProps } from "next";
 import { BlogDetail } from "@/types/BlogDetail";
+import { AuthorInfo } from "@/components/AuthorInfo";
+
+export default function BlogDetailPage({ blog }: { blog: BlogDetail }) {
+  return (
+    <article className="max-w-3xl mx-auto py-8">
+      <header>
+        <h1 className="text-3xl font-bold mb-6">{blog.title}</h1>
+
+        <address className="mb-8">
+          <AuthorInfo userName={blog.userName} userImage={blog.userImage} />
+        </address>
+      </header>
+
+      <section className="bg-gray-50 p-6 rounded-md border">
+        <div className="whitespace-pre-wrap text-gray-800">
+          {blog.content}
+        </div>
+      </section>
+    </article>
+  );
+}
 
 const API_BASE_URL = "http://localhost:5678/api/blogs";
 

--- a/src/pages/blogs/[id].tsx
+++ b/src/pages/blogs/[id].tsx
@@ -8,6 +8,14 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   try {
     const res = await fetch(`${API_BASE_URL}/${id}`);
 
+    if (res.status === 404) {
+      return { notFound: true };
+    }
+
+    if (!res.ok) {
+      throw new Error(`API Error: ${res.status}`);
+    }
+
     const blog = await res.json();
 
     return {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { GetServerSideProps } from "next";
 import { BlogInfo } from "@/types/BlogInfo";
 import { BlogCard } from "@/components/BlogCard";
+import { API_BASE_URL } from "@/lib/constants";
 import Head from "next/head";
 
 export default function Home({ blogs }: { blogs: BlogInfo[] }) {
@@ -30,8 +31,6 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
     </>
   );
 }
-
-const API_BASE_URL = "http://localhost:5678/api/blogs";
 
 export const getServerSideProps: GetServerSideProps = async () => {
   try {

--- a/src/types/BlogDetail.ts
+++ b/src/types/BlogDetail.ts
@@ -1,0 +1,5 @@
+import { BlogInfo } from "./BlogInfo";
+
+export type BlogDetail = BlogInfo & {
+  content: string;
+};


### PR DESCRIPTION
# Issue5 (feature/blog-detail)

### やったこと
1. **詳細データ用の型定義 (`src/types/BlogDetail.ts`)**
   - 記事一覧用の型を拡張し、記事本文 (`content`) を含めた `BlogDetail` 型を新規作成。
2. **個別記事表示用の動的ルーティングとデータ取得 (`src/pages/blogs/[id].tsx`)**
   - Next.js の Pages Router に基づき、`[id]` を用いた動的ルーティングファイルを新規作成。
   - `getServerSideProps` 内で `context.params?.id` を取得し、SSR で該当記事をフェッチする基本ロジックを実装。
3. **データ取得のエラーハンドリングと型安全性の向上 (`src/pages/blogs/[id].tsx`)**
   - レスポンスの404判定やAPIエラーチェック、IDパラメータの型チェックを追加。
   - 取得データへの `BlogDetail` 型の適用など、防御的プログラミングを徹底。
4. **記事詳細ページのUI構築とメタデータ追加 (`src/pages/blogs/[id].tsx`)**
   - 記事のタイトル、著者情報、本文を表示するUIレイアウトを実装。
   - `next/head` を用いて、SEO対策となる `title` と `description` メタデータを追加。
5. **API URLの管理方法改善 (`src/lib/constants.ts`)**
   - 今後の実装も見据え、APIのベースURL設定を定数ファイルに切り出して共通化（DRY原則の適用）。
6. **記事一覧からの遷移機能追加 (`src/components/BlogCard.tsx`)**
   - 一覧のカード全体を `next/link` でラップし、各記事の詳細ページへの画面遷移（リンク機能）を実装。

### 検索したこと
1. **共通化するAPI URLの管理方法（環境変数 vs 定数ファイル）**
   - 自分なりの結論: APIのエンドポイントを共通ディレクトリで管理する際、「`.env`（環境変数）を使うべきか、定数ファイルを使うべきか」を調べた。環境変数は機密情報（APIキー等）や環境（開発・本番）で値が変わる場合に適しているが、今回は単なるベースURLの重複排除（DRY）が目的であること、またローカルのモック環境であるため、シンプルに `src/lib/constants.ts` に定数として切り出し共有するアプローチを選択した。
   - 参考ソース: 
     - [Next.js公式ドキュメント - Environment Variables](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables)
     - AIとの対話

2. **Next.js での画面遷移と `next/link` の使い方**
   - 自分なりの結論: ブログ一覧のカードをクリック可能にする実装において、通常の `<a>` タグではなく Next.js の `<Link>` コンポーネントを使用する理由を調べた。`<Link>` を親としてUIコンポーネント（今回であれば `Card` 全体）をラップすることで、ページ全体のリロードを防ぎ、高速なクライアントサイドルーティング（SPAの挙動）を実現できることを再確認した。
   - 参考ソース: [Next.js公式ドキュメント - next/link](https://nextjs.org/docs/pages/api-reference/components/link)

### わかったこと
- **早期リターン（Early Return）による可読性向上:** `getServerSideProps` 内のエラー判定をネストさせず、即座に `notFound: true` を返すように書くことで、正常系のロジックが追いやすくなることを学んだ。
- **防御的プログラミング:** `context.params.id` が `string` であることを厳密にチェックしてからAPIリクエストを送ることで、予期せぬエラーを防ぐ設計の重要性を理解した。

### 詰まったこと
- 共通化するAPI URLの管理方法（環境変数 vs 定数ファイル）についてどちらがいいのかを悩み。結局、YAGNI原則から定数ファイルにした。

**【⚠️ レビュアーの方へ】**
このPRは `feature/blog-card` (Issue 3) から派生しています。
差分をIssue 4の（feature/blog-detail）ブランチ内容のみに絞るため、一時的に `base` ブランチを `feature/blog-card` に設定しています。最終的には `main` へマージ予定です。