### PR TITLE
style: ブログ記事ページの見た目を整える

### DIFF
--- a/src/pages/blogs/[id].tsx
+++ b/src/pages/blogs/[id].tsx
@@ -17,16 +17,21 @@ export default function BlogDetailPage({ blog }: { blog: BlogDetail }) {
         />
       </Head>
 
-      <article className="max-w-3xl mx-auto py-8">
+      <article className="max-w-3xl mx-auto">
         <header>
-          <h1 className="text-3xl font-bold mb-6">{blog.title}</h1>
+          <h1 className="text-3xl md:text-4xl font-bold mb-6 md:mb-8 leading-tight tracking-tight text-gray-900">
+            {blog.title}
+          </h1>
 
-          <address className="mb-8">
+          <address className="mb-6 md:mb-8" aria-label="記事の著者情報">
             <AuthorInfo userName={blog.userName} userImage={blog.userImage} />
           </address>
         </header>
 
-        <section className="bg-gray-50 p-6 rounded-md border text-gray-800 prose prose-slate max-w-none">
+        <section
+          className="bg-gray-50 p-4 sm:p-6 md:p-8 rounded-md border text-gray-800 prose prose-base md:prose-lg prose-slate max-w-none break-words"
+          aria-label="記事本文"
+        >
           <ReactMarkdown remarkPlugins={[remarkGfm]}>
             {blog.content}
           </ReactMarkdown>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,10 +12,15 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
         <meta name="description" content="記事一覧ページです。" />
       </Head>
 
-      <section className="space-y-4">
-        <h1 className="text-2xl font-bold mb-6">ブログ記事一覧</h1>
+      <section className="max-w-4xl mx-auto" aria-labelledby="blog-list-title">
+        <h1
+          id="blog-list-title"
+          className="text-2xl md:text-3xl font-bold text-gray-900 mb-6 md:mb-8 tracking-tight"
+        >
+          ブログ記事一覧
+        </h1>
 
-        <ul className="space-y-4">
+        <ul className="space-y-4 md:space-y-6">
           {blogs.map((blog) => (
             <li key={blog.id}>
               <BlogCard


### PR DESCRIPTION
# Issue7 (feature/blog-style)

### やったこと
1. **記事一覧ページのレスポンシブ対応とa11y改善 (`src/pages/index.tsx`)**
   - 超ワイド画面でも読みやすいよう、一覧全体を `max-w-4xl mx-auto` で中央揃えに制限しました。
   - 見出しの文字サイズと記事カード間の余白を `text-2xl md:text-3xl`、`space-y-4 md:space-y-6` でレスポンシブに調整しました。
   - 見出し (`h1`) に `id` を付与し、`<section>` で `aria-labelledby` として参照することで、スクリーンリーダーがセクション目的を正確に読み上げられるようにしました。

2. **記事詳細ページのレスポンシブ対応とa11y改善 (`src/pages/blogs/[id].tsx`)**
   - 記事タイトルのサイズを `text-3xl md:text-4xl` にし、モバイル環境での可読性を確保しました。
   - 本文（`prose`）をデフォルト寄りの `prose-base md:prose-lg` に最適化し、スマートフォンでも読みやすいサイズを維持しました。
   - 著者情報セクションに `aria-label="記事の著者情報"`、本文セクションに `aria-label="記事本文"` を付与し、スクリーンリーダー対応を強化しました。
   - パディングを `p-4 sm:p-6 md:p-8` でレスポンシブに調整し、親レイアウト（`_app.tsx`）との余白依存関係を整理しました。

### 検索したこと
1. **Web記事UIのデファクトスタンダード（タイポグラフィとレスポンシブ設計）**
   - 自分なりの結論: Qiitaやノート系技術メディアの実装を確認し、「本文はスマホで16px相当を維持」「タイトルは28～32px相当」「行間は本文1.7前後、見出し1.2～1.3」というデファクト寄りの設定が、ユーザー体験と可読性のバランスを最適化することを理解しました。
   - 参考ソース: 実装確認、デベロッパーツールのデバッグ

2. **アクセシビリティ属性（aria-label / aria-labelledby）の使い分け**
   - 自分なりの結論: `aria-labelledby` は「セクションが内部の見出しタグで既に ラベル付けされている場合」、`aria-label` は「見出しが存在しない/不可視である場合」に使い分けることで、スクリーンリーダーが冗長に読み上げずに最適なセマンティクスを提供できることを理解しました。
   - 参考ソース: 
    -対話型AI

### わかったこと
- **親子間のレイアウト責務の分離の重要性:** CSSは本来「全体から部分へ、親から子へ」と段階的に制御するもの。親で一度決めた規則を子で上書きすると、保守性が落ちるだけでなくバグの原因になる。
- **デファクト寄りの判断の価値:** Qiitaなど実績のあるUI/UXから学ぶことで、「なぜそのサイズなのか」「なぜそのレイアウトなのか」という根拠ある判断ができるようになりました。
- **デベロッパーツールの活用例:** Chrome DevToolsの「Computed」タブで、実際に適用されているスタイルを確認することで、意図と実装の乖離を検出できることがわかりました。

### 詰まったこと
- **スマホサイズで文字が小さくなり過ぎた問題:** 最初は `prose-sm` や `text-2xl` でレスポンシブ対応しようとしましたが、デファクトスタンダードより小さくなってしまいました。ユーザー要望と参考実装を基に、`prose-base` と `text-3xl` へ調整することで解決しました。
- **親レイアウトとの二重padding問題:** 親で既に `px-4` が設定されているのに、子で再び `px-4 sm:px-0` を追加してしまい、CSSの依存関係による弊害を経験しました。

**【⚠️ レビュアーの方へ】**
このPRは `feature/react-markdown` (Issue 5) から派生しています。
差分をIssue 6の（feature/blog-style）ブランチ内容のみに絞るため、一時的に `base` ブランチを `feature/react-markdown` に設定しています。最終的には `main` へマージ予定です。