### PR TITLE
feat: 記事一覧ページに検索機能を実装

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -58,7 +58,7 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
         </div>
 
         {filteredBlogs.length === 0 ? (
-          <p className="text-center text-gray-500 py-10">
+          <p className="text-center text-gray-500 py-10" role="status">
             「{searchQuery}」に一致する記事は見つかりませんでした。
           </p>
         ) : (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,7 +23,10 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
   };
 
   const filteredBlogs = blogs.filter((blog) => {
-    const lowerQuery = searchQuery.toLowerCase();
+    const lowerQuery = searchQuery.trim().toLowerCase();
+
+    if (!lowerQuery) return true;
+
     return blog.title.toLowerCase().includes(lowerQuery);
   });
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,14 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
 
   const [searchQuery, setSearchQuery] = useState("");
 
-  const visibleBlogs = blogs.slice(0, visibleCount);
+  const filteredBlogs = blogs.filter((blog) => {
+    const lowerQuery = searchQuery.toLowerCase();
+    return (
+      blog.title.toLowerCase().includes(lowerQuery)
+    );
+  });
+
+  const visibleBlogs = filteredBlogs.slice(0, visibleCount);
 
   const handleLoadMore = () => {
     setVisibleCount((prev) => prev + BLOGS_PER_LOAD);
@@ -59,7 +66,7 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
           ))}
         </ul>
 
-        {visibleCount < blogs.length && (
+        {visibleCount < filteredBlogs.length && (
           <div className="mt-8 flex justify-center">
             <Button
               variant="outline"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -57,18 +57,24 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
           />
         </div>
 
-        <ul className="space-y-4 md:space-y-6">
-          {visibleBlogs.map((blog) => (
-            <li key={blog.id}>
-              <BlogCard
-                id={blog.id}
-                title={blog.title}
-                userName={blog.userName}
-                userImage={blog.userImage}
-              />
-            </li>
-          ))}
-        </ul>
+        {filteredBlogs.length === 0 ? (
+          <p className="text-center text-gray-500 py-10">
+            「{searchQuery}」に一致する記事は見つかりませんでした。
+          </p>
+        ) : (
+          <ul className="space-y-4 md:space-y-6">
+            {visibleBlogs.map((blog) => (
+              <li key={blog.id}>
+                <BlogCard
+                  id={blog.id}
+                  title={blog.title}
+                  userName={blog.userName}
+                  userImage={blog.userImage}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
 
         {visibleCount < filteredBlogs.length && (
           <div className="mt-8 flex justify-center">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import { BlogInfo } from "@/types/BlogInfo";
 import { BlogCard } from "@/components/BlogCard";
 import { API_BASE_URL } from "@/lib/constants";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import Head from "next/head";
 
 const INITIAL_BLOGS_TO_SHOW = 10;
@@ -12,6 +13,9 @@ const BLOGS_PER_LOAD = 10;
 export default function Home({ blogs }: { blogs: BlogInfo[] }) {
 
   const [visibleCount, setVisibleCount] = useState<number>(INITIAL_BLOGS_TO_SHOW);
+
+  const [searchQuery, setSearchQuery] = useState("");
+
   const visibleBlogs = blogs.slice(0, visibleCount);
 
   const handleLoadMore = () => {
@@ -32,6 +36,15 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
         >
           ブログ記事一覧
         </h1>
+
+        <div className="mb-8">
+          <Input
+            type="search"
+            placeholder="記事を検索..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+        </div>
 
         <ul className="space-y-4 md:space-y-6">
           {visibleBlogs.map((blog) => (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -55,6 +55,7 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
           <Input
             type="search"
             placeholder="記事を検索..."
+            aria-label="記事を検索"
             value={searchQuery}
             onChange={handleSearchChange}
           />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,11 +16,15 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
 
   const [searchQuery, setSearchQuery] = useState("");
 
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearchQuery(value);
+    setVisibleCount(INITIAL_BLOGS_TO_SHOW);
+  };
+
   const filteredBlogs = blogs.filter((blog) => {
     const lowerQuery = searchQuery.toLowerCase();
-    return (
-      blog.title.toLowerCase().includes(lowerQuery)
-    );
+    return blog.title.toLowerCase().includes(lowerQuery);
   });
 
   const visibleBlogs = filteredBlogs.slice(0, visibleCount);
@@ -49,7 +53,7 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
             type="search"
             placeholder="記事を検索..."
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            onChange={handleSearchChange}
           />
         </div>
 


### PR DESCRIPTION
## 関連Issue
Closes #9

## Issue2 (feature/search)

### やったこと
1. **UIコンポーネントの導入**
   - shadcn/uiの `Input` コンポーネントをプロジェクトに追加。
2. **検索キーワードの状態管理と入力フォームの実装**
   - `searchQuery` ステートを定義。
   - `section` > `h1` の直下に `Input` コンポーネントを配置し、制御コンポーネントとして実装。
3. **クライアントサイドでの記事絞り込みロジックの実装**
   - 既存のAPI仕様（一覧データに本文が含まれていないこと）に従い、今回は検索対象を `title` のみに設定して実装。
4. **検索ハンドラの抽出と検索時の表示件数リセット処理**
   - 入力時にクエリ更新と `visibleCount` の初期化を同時に行う `handleSearchChange` 関数を抽出。
   - `useEffect` を使わずにイベントハンドラ内で完結させることで、不要な再レンダリングを防止。
5. **検索結果0件時のメッセージ表示（Empty State）の実装**
   - 該当記事がない場合（`filteredBlogs.length === 0`）に、検索クエリを含めたメッセージを表示する条件分岐をJSXに追加。
6. **堅牢性・アクセシビリティの向上**
   - 検索クエリと記事タイトルの双方に `.toLowerCase()` を適用し、大文字・小文字の違いを吸収する堅牢な処理を実装。
   - 検索フォームに `type="search"` 属性を指定し、ブラウザ標準の検索機能としてのセマンティクスとアクセシビリティを確保。

### 検索したこと
1. **要件とAPI仕様の不整合に関する事実確認**
   - 自分なりの結論: 要件には「本文検索」とあるが、`/api/blogs`（一覧API）のレスポンスに `content` が含まれていないことをSwaggerおよび実際のレスポンスから確認。既存のAPI仕様に従い、今回はタイトル検索のみにスコープを絞るのが適切と判断した。
   - 参考ソース: Swagger API仕様書、ネットワークタブでのレスポンス検証、対話型AI
2. **useDeferredValue によるレンダリング最適化の要否（YAGNI原則）**
   - 自分なりの結論: 検索入力時のレンダリング遅延を防ぐための `useDeferredValue` の導入を検討したが、現在のデータ件数においては複雑化のデメリットが上回る。YAGNI原則に則り、今回は過剰な最適化を見送った。
   - 参考ソース: [React公式ドキュメント (useDeferredValue)](https://ja.react.dev/reference/react/useDeferredValue)、対話型AI
3. **Stateの変更に連動した処理（useEffectのアンチパターン）**
   - 自分なりの結論: 検索クエリの変更に連動して表示件数をリセットする際、`useEffect` で監視すると不要なレンダリングが追加で発生する。イベントの発生元である `onChange` ハンドラ内で直接Stateを更新する方が適切であると確認した。
   - 参考ソース: [React公式ドキュメント (エフェクトは不要かもしれない)](https://ja.react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)

### わかったこと
- **過剰防衛の排除とシンプルさの維持**: 高度なパフォーマンスチューニング（useDeferredValue等）は、実際にボトルネックが発生してから導入すべきであり、「念のため」で複雑なコードを入れるのは避けるべきであるという実践的な感覚を掴んだ。
- **仕様の矛盾に対するアプローチ**: 要件定義とシステムの現状が食い違っている場合、無理なハックをするのではなく、事実（データがないこと）に基づいて実装のスコープを適切に調整する重要性を学んだ。

### 詰まったこと
- APIレスポンスに `content`（本文）が含まれていないことに気づき、どのように要件を満たすべきか実装方針に迷ったが、現状のAPI仕様を正としてタイトルのみの検索に絞ることで解決した。
- パフォーマンス向上のための最適化フックを導入するかどうか迷ったが、現在の規模感とYAGNI原則に照らし合わせ、あえて導入しないという設計判断に至るまで少し思考を要した。

**【⚠️ レビュアーの方へ】**
このPRは `feature/pagination` から派生しています。
差分をIssue 1の（feature/search）ブランチ内容のみに絞るため、一時的に `base` ブランチを `feature/pagination` に設定しています。最終的には `main` へマージ予定です。