### PR TITLE
feat: ブログ詳細ページに「いいね」機能を実装

### DIFF
--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -4,8 +4,8 @@ import { Heart } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export function LikeButton() {
-  const [likeCount, setLikeCount] = useState<number>(0);
-  const [isLiked, setIsLiked] = useState<boolean>(false);
+  const [likeCount, setLikeCount] = useState(0);
+  const [isLiked, setIsLiked] = useState(false);
 
   const handleToggleLike = () => {
     if (isLiked) {

--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Heart } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function LikeButton() {
+  const [likeCount, setLikeCount] = useState<number>(0);
+  const [isLiked, setIsLiked] = useState<boolean>(false);
+
+  const handleToggleLike = () => {
+    if (isLiked) {
+      setLikeCount((prev) => prev - 1);
+      setIsLiked(false);
+    } else {
+      setLikeCount((prev) => prev + 1);
+      setIsLiked(true);
+    }
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleToggleLike}
+      aria-pressed={isLiked}
+      aria-label={isLiked ? "いいねを取り消す" : "この記事にいいねする"}
+      className={cn(
+        "flex items-center gap-2 rounded-full px-4 transition-colors duration-200",
+        isLiked
+          ? "border-pink-500 text-pink-500 bg-pink-50 hover:bg-pink-100 hover:text-pink-600"
+          : "text-gray-500 hover:text-gray-700"
+      )}
+    >
+      <Heart
+        className={cn(
+          "w-5 h-5 transition-all duration-200",
+          isLiked ? "fill-current scale-110" : "scale-100"
+        )}
+      />
+      <span className="text-base font-semibold">{likeCount}</span>
+    </Button>
+  );
+}

--- a/src/pages/blogs/[id].tsx
+++ b/src/pages/blogs/[id].tsx
@@ -1,28 +1,13 @@
-import { useState } from "react";
 import { GetServerSideProps } from "next";
 import Head from "next/head";
-import { Button } from "@/components/ui/button";
-import { Heart } from "lucide-react";
 import { BlogDetail } from "@/types/BlogDetail";
 import { AuthorInfo } from "@/components/AuthorInfo";
+import { LikeButton } from "@/components/LikeButton";
 import { API_BASE_URL } from "@/lib/constants";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 export default function BlogDetailPage({ blog }: { blog: BlogDetail }) {
-  const [likeCount, setLikeCount] = useState<number>(0);
-  const [isLiked, setIsLiked] = useState<boolean>(false);
-
-  const handleToggleLike = () => {
-    if (isLiked) {
-      setLikeCount((prev) => prev - 1);
-      setIsLiked(false);
-    } else {
-      setLikeCount((prev) => prev + 1);
-      setIsLiked(true);
-    }
-  };
-
   return (
     <>
       <Head>
@@ -44,25 +29,7 @@ export default function BlogDetailPage({ blog }: { blog: BlogDetail }) {
               <AuthorInfo userName={blog.userName} userImage={blog.userImage} />
             </address>
 
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleToggleLike}
-              aria-pressed={isLiked}
-              aria-label={isLiked ? "いいねを取り消す" : "この記事にいいねする"}
-              className={`flex items-center gap-2 rounded-full px-4 transition-colors duration-200 ${
-                isLiked
-                  ? "border-pink-500 text-pink-500 bg-pink-50 hover:bg-pink-100 hover:text-pink-600"
-                  : "text-gray-500 hover:text-gray-700"
-              }`}
-            >
-              <Heart
-                className={`w-5 h-5 transition-all duration-200 ${
-                  isLiked ? "fill-current scale-110" : "scale-100"
-                }`}
-              />
-              <span className="text-base font-semibold">{likeCount}</span>
-            </Button>
+            <LikeButton />
           </div>
         </header>
 

--- a/src/pages/blogs/[id].tsx
+++ b/src/pages/blogs/[id].tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { GetServerSideProps } from "next";
 import Head from "next/head";
 import { BlogDetail } from "@/types/BlogDetail";
@@ -7,6 +8,9 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 export default function BlogDetailPage({ blog }: { blog: BlogDetail }) {
+  const [likeCount, setLikeCount] = useState<number>(0);
+  const [isLiked, setIsLiked] = useState<boolean>(false);
+
   return (
     <>
       <Head>

--- a/src/pages/blogs/[id].tsx
+++ b/src/pages/blogs/[id].tsx
@@ -11,6 +11,16 @@ export default function BlogDetailPage({ blog }: { blog: BlogDetail }) {
   const [likeCount, setLikeCount] = useState<number>(0);
   const [isLiked, setIsLiked] = useState<boolean>(false);
 
+  const handleToggleLike = () => {
+    if (isLiked) {
+      setLikeCount((prev) => prev - 1);
+      setIsLiked(false);
+    } else {
+      setLikeCount((prev) => prev + 1);
+      setIsLiked(true);
+    }
+  };
+
   return (
     <>
       <Head>

--- a/src/pages/blogs/[id].tsx
+++ b/src/pages/blogs/[id].tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { GetServerSideProps } from "next";
 import Head from "next/head";
+import { Button } from "@/components/ui/button";
+import { Heart } from "lucide-react";
 import { BlogDetail } from "@/types/BlogDetail";
 import { AuthorInfo } from "@/components/AuthorInfo";
 import { API_BASE_URL } from "@/lib/constants";
@@ -37,9 +39,31 @@ export default function BlogDetailPage({ blog }: { blog: BlogDetail }) {
             {blog.title}
           </h1>
 
-          <address className="mb-6 md:mb-8" aria-label="記事の著者情報">
-            <AuthorInfo userName={blog.userName} userImage={blog.userImage} />
-          </address>
+          <div className="flex flex-wrap items-center justify-between gap-4 mb-6 md:mb-8">
+            <address aria-label="記事の著者情報">
+              <AuthorInfo userName={blog.userName} userImage={blog.userImage} />
+            </address>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleToggleLike}
+              aria-pressed={isLiked}
+              aria-label={isLiked ? "いいねを取り消す" : "この記事にいいねする"}
+              className={`flex items-center gap-2 rounded-full px-4 transition-colors duration-200 ${
+                isLiked
+                  ? "border-pink-500 text-pink-500 bg-pink-50 hover:bg-pink-100 hover:text-pink-600"
+                  : "text-gray-500 hover:text-gray-700"
+              }`}
+            >
+              <Heart
+                className={`w-5 h-5 transition-all duration-200 ${
+                  isLiked ? "fill-current scale-110" : "scale-100"
+                }`}
+              />
+              <span className="text-base font-semibold">{likeCount}</span>
+            </Button>
+          </div>
         </header>
 
         <section


### PR DESCRIPTION
## 関連Issue
Closes #10 

## Issue3 (feature/like-button)

### やったこと
1. **いいね機能のためのState定義**
   - いいね数（`likeCount`）と判定フラグ（`isLiked`）を管理するStateを定義。
2. **いいねの追加・取り消しを行うトグルロジックの実装**
   - 1回押すと追加、もう1回押すと取り消される実務的なUXを考慮したトグル関数（`handleToggleLike`）を実装。
3. **ヘッダー部分へのボタン配置と動的スタイリング**
   - 記事詳細ページ（`[id].tsx`）のヘッダー領域（著者情報の横）に `lucide-react` のHeartアイコンを含むボタンを配置。
   - `isLiked` の状態に応じて、アイコンの塗りつぶし（`fill-current`）や枠線・背景色がピンクに切り替わるTailwindの動的クラスを実装。
   - `aria-pressed` や `aria-label` を用い、スクリーンリーダー向けの状態通知を実装。
4. **【リファクタリング】LikeButtonコンポーネントとしての切り出し**
   - ページコンポーネント（`[id].tsx`）の肥大化を防ぐため、特定のState（いいね）にのみ依存するUI一式を `<LikeButton />` として分離し、凝集度とカプセル化を向上。
5. **【リファクタリング】TypeScriptの型推論の活用**
   - `useState` における冗長なプリミティブ型指定（`<number>` や `<boolean>`）を削除し、初期値からの型推論を活用するベストプラクティスを適用。

### 検索したこと
1. **Reactにおけるコンポーネントの分割基準（凝集度とカプセル化）**
   - 自分なりの結論: 複数のUI要素（ボタン、アイコン、数値）が同一のStateに完全に依存して変化する場合、それらを一つのコンポーネントにまとめることで凝集度が高まる。また、親コンポーネント（ページ）から内部の実装詳細を隠蔽（カプセル化）できるため、保守性が向上すると理解した。
   - 参考ソース: [React公式ドキュメント (State の保持とリセット)](https://ja.react.dev/learn/preserving-and-resetting-state) / 対話型AI
2. **TypeScriptの型推論と `useState` のジェネリクス指定の境界線**
   - 自分なりの結論: プリミティブ型（数値、文字列、真偽値）で初期値が与えられている場合はTSの型推論に任せるのが実務的。一方で、初期値が `null` や空配列 `[]` の場合のみジェネリクスで型を明示するべきであると学んだ。
   - 参考ソース: [サバイバルTypeScript (型推論)](https://typescriptbook.jp/reference/values-types-variables/type-inference)

### わかったこと
- **UXを考慮したUI配置**: 当初は記事の末尾への配置を想定していたが、実際のブログメディア（Qiita等）の利用動線を考えると、読了前でも押しやすい「タイトルの下（ヘッダー部分）」に置くのがベストプラクティスであるという視点を持てた。
- **YAGNI原則とコンポーネント切り出しの判断**: 「再利用しないなら切り出さない」のが基本だが、今回のように「特定のStateとそのStateで動くUI群」が明確に存在する場合は、親の責務を減らすために切り出す（コロケーション）のがReactの正しい設計であると腑に落ちた。

### 詰まったこと
- `<Button>` というコンポーネント名でありながら、中にアイコンや数値を入れて切り出しても良いのか（責務として大きすぎないか）迷ったが、ドメインに特化した一つの「Widget（機能の塊）」として捉えることで設計の違和感を解消できた。

**【⚠️ レビュアーの方へ】**
このPRは `feature/search` から派生しています。
差分をIssue 3の（feature/like-button）ブランチ内容のみに絞るため、一時的に `base` ブランチを `feature/like-button` に設定しています。最終的には `main` へマージ予定です。