### PR TITLE
feat: 記事一覧ページに「もっと読む」ボタンによるページネーション機能を実装（再）

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,6 +14,10 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
   const [visibleCount, setVisibleCount] = useState<number>(INITIAL_BLOGS_TO_SHOW);
   const visibleBlogs = blogs.slice(0, visibleCount);
 
+  const handleLoadMore = () => {
+    setVisibleCount((prev) => prev + BLOGS_PER_LOAD);
+  };
+
   return (
     <>
       <Head>
@@ -44,7 +48,7 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
 
         {visibleCount < blogs.length && (
           <div className="mt-8 flex justify-center">
-            <Button onClick={() => setVisibleCount((prev) => prev + BLOGS_PER_LOAD)}>
+            <Button onClick={handleLoadMore}>
               もっと読む
             </Button>
           </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -52,6 +52,7 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
               variant="outline"
               size="lg"
               className="w-full sm:w-64 rounded-full"
+              aria-label="さらに記事を読み込む"
               onClick={handleLoadMore}
             >
               もっと読む

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { GetServerSideProps } from "next";
 import { BlogInfo } from "@/types/BlogInfo";
 import { BlogCard } from "@/components/BlogCard";
@@ -5,6 +6,10 @@ import { API_BASE_URL } from "@/lib/constants";
 import Head from "next/head";
 
 export default function Home({ blogs }: { blogs: BlogInfo[] }) {
+
+  const [visibleCount, setVisibleCount] = useState<number>(10);
+  const visibleBlogs = blogs.slice(0, visibleCount);
+
   return (
     <>
       <Head>
@@ -21,7 +26,7 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
         </h1>
 
         <ul className="space-y-4 md:space-y-6">
-          {blogs.map((blog) => (
+          {visibleBlogs.map((blog) => (
             <li key={blog.id}>
               <BlogCard
                 id={blog.id}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,9 +6,12 @@ import { API_BASE_URL } from "@/lib/constants";
 import { Button } from "@/components/ui/button";
 import Head from "next/head";
 
+const INITIAL_BLOGS_TO_SHOW = 10;
+const BLOGS_PER_LOAD = 10;
+
 export default function Home({ blogs }: { blogs: BlogInfo[] }) {
 
-  const [visibleCount, setVisibleCount] = useState<number>(10);
+  const [visibleCount, setVisibleCount] = useState<number>(INITIAL_BLOGS_TO_SHOW);
   const visibleBlogs = blogs.slice(0, visibleCount);
 
   return (
@@ -41,7 +44,7 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
 
         {visibleCount < blogs.length && (
           <div className="mt-8 flex justify-center">
-            <Button onClick={() => setVisibleCount((prev) => prev + 10)}>
+            <Button onClick={() => setVisibleCount((prev) => prev + BLOGS_PER_LOAD)}>
               もっと読む
             </Button>
           </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -48,7 +48,12 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
 
         {visibleCount < blogs.length && (
           <div className="mt-8 flex justify-center">
-            <Button onClick={handleLoadMore}>
+            <Button
+              variant="outline"
+              size="lg"
+              className="w-full sm:w-64 rounded-full"
+              onClick={handleLoadMore}
+            >
               もっと読む
             </Button>
           </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,7 @@ import { GetServerSideProps } from "next";
 import { BlogInfo } from "@/types/BlogInfo";
 import { BlogCard } from "@/components/BlogCard";
 import { API_BASE_URL } from "@/lib/constants";
+import { Button } from "@/components/ui/button";
 import Head from "next/head";
 
 export default function Home({ blogs }: { blogs: BlogInfo[] }) {
@@ -37,6 +38,14 @@ export default function Home({ blogs }: { blogs: BlogInfo[] }) {
             </li>
           ))}
         </ul>
+
+        {visibleCount < blogs.length && (
+          <div className="mt-8 flex justify-center">
+            <Button onClick={() => setVisibleCount((prev) => prev + 10)}>
+              もっと読む
+            </Button>
+          </div>
+        )}
       </section>
     </>
   );


### PR DESCRIPTION
## 関連Issue
Closes #8 

## PR #12  のbase（04-next-2）削除に伴い、base=main で作り直したPRです。

## Issue1 (feature/pagination)

### やったこと
1. **表示件数制御の基本ロジック実装**
   - `src/pages/index.tsx` に `useState` を導入し、初期表示を10件に制限。
   - 配列の `slice` メソッドを用いて、クライアントサイドでの動的な表示切り替えを実装。
2. **「もっと読む」ボタンの追加と機能実装**
   - 全記事数より表示件数が少ない場合のみ表示される条件付きレンダリングを実装。
   - ボタン押下時に `setVisibleCount` を実行し、表示上限を増やす機能を実装。
3. **リファクタリング：定数化とマジックナンバーの排除**
   - 設定値を `INITIAL_BLOGS_TO_SHOW` と `BLOGS_PER_LOAD` に定数化。
   - 「初期値」と「変化量」という役割の違いを明確に定義。
4. **リファクタリング：イベントハンドラの抽出**
   - JSX内に記述していた更新ロジックを、独立した関数 `handleLoadMore` に抽出。
5. **アクセシビリティ対応**
   - ボタンに `aria-label="さらに記事を読み込む"` を付与し、スクリーンリーダー対応を強化。

### 検索したこと
1. **useMemo による最適化の妥当性**
   - 自分なりの結論: `slice` 処理は非常に軽量であり、今回のデータ規模では `useMemo` の内部コスト（依存配列の比較等）の方がオーバーヘッドになる。安易なメモ化は避け、まずはシンプルに記述すべきと判断。
   - 参考ソース: [React公式ドキュメント (useMemo)](https://ja.react.dev/reference/react/useMemo#should-you-add-usememo-everywhere)
2. **ドメイン用語の統一と認知負荷**
   - 自分なりの結論: 既存の型定義(`BlogInfo`)やProps(`blogs`)が存在する中で、安易に `post` という別単語を変数名に用いるとチーム開発における認知負荷が上がる。コンテキスト内で言葉（今回は `blog` ）を統一することで、可読性と保守性が向上することを確認。
   - 参考ソース: 対話型AI
3. **useState の更新関数（関数型アップデート）**
   - 自分なりの結論: `prev => prev + ...` の形式をとることで、非同期なステート更新時でも常に最新の値を参照できる安全な実装になると理解。
   - 参考ソース: [React公式ドキュメント (useState: 前の状態に基づいて状態を更新する)](https://ja.react.dev/reference/react/useState#updating-state-based-on-the-previous-state)

### わかったこと
- **YAGNI原則の遵守**: 「将来のため」の過剰な最適化やガード（Math.min等）は、現在のシンプルさを損なう。今の要件に過不足なく答える設計が実務では重要。
- - **命名の意図（認知負荷とドメイン駆動の視点）**:
  単に `COUNT` や `LIMIT` と紐付けるのではなく、具体的なドメイン用語を用いた `INITIAL_BLOGS_TO_SHOW`（表示するブログの初期数）や `BLOGS_PER_LOAD`（1クリックあたりのブログ数）と命名することで、以下の利点があることを学んだ。
  1. `LIMIT`（制限）という受動的な視点ではなく、「能動的に何件表示/追加するのか」というUI・開発者のメンタルモデルに一致する。
  2. 日本人にとって「Count（カウントする）」が動詞として無意識に認識されることによる、処理を読む際の認知的負荷（読みづらさ）を排除できる。
  3. `ITEMS` のような汎用語ではなく `BLOGS` というプロジェクト内の共通言語（ユビキタス言語）を使うことで、コードと実態の結びつきがより直牢になる。

### 詰まったこと
- マジックナンバーの定数化において、同じ「10」という数値でも、用途（初期表示件数と追加件数）ごとに定数を分けるべきか、1つにまとめるべきかの設計判断に迷った。
- 実装の堅牢性を高めるために `useMemo` や `Math.min` などのガード処理を導入すべきか検討したが、現在の要件に対してそれが「適切な設計」なのか「過剰な設計（YAGNI原則違反）」なのか、その境界線の判断に悩んだ。
- 定数名の命名において、初期は受動的な印象の `LIMIT` や、動詞と混同しやすい `COUNT`、汎用的な `ITEMS` などを検討したが、UIの能動的な振る舞いとドメイン（`BLOGS`）を正確に反映し、開発者の認知負荷を最小限に抑える最適な命名（`INITIAL_BLOGS_TO_SHOW`, `BLOGS_PER_LOAD`）に落とし込むまでの言語化と設計判断に非常に悩んだ。

**【⚠️ レビュアーの方へ】**
このPRは `04-next-2` から派生しています。
差分をIssue 1の（feature/pagination）ブランチ内容のみに絞るため、一時的に `base` ブランチを `04-next-2` に設定しています。最終的には `main` へマージ予定です。