### PR TITLE
feat: ヘッダーにナビゲーションを実装した（ロゴ→一覧 / 新規投稿リンク）

### DIFF
--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -12,7 +12,7 @@ export function Header() {
         </Link>
         <Link
           href="/blogs/new"
-          className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900"
+          className="flex items-center self-stretch border-x border-gray-300 px-6 text-sm font-medium text-gray-900 transition-colors hover:bg-gray-50"
         >
           新規投稿
         </Link>

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,9 +1,22 @@
+import Link from "next/link";
+
 export function Header() {
   return (
     <header className="w-full border-b bg-white">
-      <div className="container mx-auto flex h-16 items-center px-4">
-        <h1 className="text-xl font-bold">Algo Blog</h1>
-      </div>
+      <nav
+        aria-label="メインナビゲーション"
+        className="container mx-auto flex h-16 items-center justify-between px-4"
+      >
+        <Link href="/" className="text-xl font-bold">
+          Algo Blog
+        </Link>
+        <Link
+          href="/blogs/new"
+          className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900"
+        >
+          新規投稿
+        </Link>
+      </nav>
     </header>
   );
 }

--- a/src/pages/blogs/new.tsx
+++ b/src/pages/blogs/new.tsx
@@ -1,0 +1,3 @@
+export default function CreateBlogPage() {
+  return <p>新規投稿ページです</p>;
+}


### PR DESCRIPTION
## 関連Issue
Closes #17 

## Issue4 (feature/header-navigation)

### やったこと

#### 1. ヘッダーのナビゲーション化（`src/components/layouts/Header.tsx`）
- `next/link` でナビゲーションを実装。
  - ロゴ「Algo Blog」… `/`（記事一覧）へのリンク
  - 「新規投稿」… `/blogs/new` へのリンク
- ナビ領域を `<nav aria-label="メインナビゲーション">` で囲み、`justify-between` で左右に配置。
- ロゴを `<h1>` から外しリンク化し、記事詳細ページ（`[id].tsx`）の記事タイトル h1 との重複を解消。
- 「新規投稿」は左右の縦仕切り線付きのナビセルにし、ホバーで背景を変化させて視認性を確保。

#### 2. 新規投稿ページのプレースホルダー作成（`src/pages/blogs/new.tsx`）
- `/blogs/new` でアクセスできるページを追加し「新規投稿ページです」を表示。フォーム本実装は後続の `feature/create-blog` で対応する。

### 検索したこと
1. **ナビゲーションを `next/link` にすべきか `router.push()` にすべきか**
   - 結論: ユーザーがクリックして移動するリンクは `next/link`（実体が `<a href>`）が適切。クローラに発見され（SEO）、スクリーンリーダーに「リンク」と伝わり（a11y）、新規タブ・先読み等のブラウザ標準機能も働く。`router.push()` はフォーム送信後のリダイレクト等、クリック以外のプログラム遷移に用いる。
2. **共通ヘッダーに `<h1>` を置くことの是非**
   - 結論: h1 は各ページの主見出しで1ページ1つが理想。全ページ共通ヘッダーにサイト名の h1 を置くと、記事詳細ページの記事タイトル h1 と重複・競合する。ロゴは見出しではなくホームへのリンクなので h1 を外した。

### わかったこと
- **リンクは「見た目」より「実体（`<a href>`）」が重要**: `onClick` + `router.push()` でも左クリックは同じに動くが、SEO・支援技術・新規タブ・キーボード操作といったリンク本来の性質を失う。ナビは本物のリンクで作るべき。
- **h1 はページ単位で設計する**: 共通レイアウト（ヘッダー）と各ページの見出し構造が衝突しないよう、見出しレベルは全体で整合させる必要がある。

### 詰まったこと
- 「新規投稿」のスタイルが当初グレー文字で目立たず、ボタン化も検討したが主張が強すぎた。最終的に左右の縦仕切り線＋ホバー反応のナビセルに落ち着いた。

### 動作確認（受け入れ条件）
- [x] 「Algo Blog」で `/`、「新規投稿」で `/blogs/new` に遷移する
- [x] 記事詳細ページの h1 が記事タイトルのみになっている